### PR TITLE
Improved type inference

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ interface IConstructor extends Function {
   visible: string[];
 }
 
-export default <M extends typeof Model>(ModelClass: typeof Model): M => {
+export default <M extends typeof Model>(ModelClass: M): M => {
   return class extends ModelClass {
     public $formatJson(json: {}) {
       let formattedJson = super.$formatJson(json);


### PR DESCRIPTION
Allows typescript to infer the type of `ModelClass`. If `ModelClass` had some extensions applied, they will be conserved and passed on to other mixins.